### PR TITLE
Update Parsers compat to include v2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 FixedSizeStrings = "0.1"
 Formatting = "0.4"
-Parsers = "1.0"
+Parsers = "1, 2"
 Tables = "1.0"
 julia = "1.5"
 


### PR DESCRIPTION
Nothing changed in the `Parsers.parse` or `Parsers.tryparse` contracts, so this shouldn't cause any problems.